### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#Live Coding Kit For Löve
+# Live Coding Kit For Löve
 
 A small live coding library for Löve which also enables interactive debugging. It basically just is a customized [love.run](https://love2d.org/wiki/love.run) which presses all errors to the command line(or in debug mode on screen). And reloads the “main.lua” everytime you save.
 
 note: still in development - everything can change
 
-#Optional Parameters
+# Optional Parameters
 * lick.file = "<INSERT CUSTOM FILE HERE>" -- default is "main.lua"
 * lick.debug = true -- displays errors in love window
 * lick.reset = true -- calls love.load everytime you save the file, if set to false it will only be called when starting Löve
 * lick.clearFlag = false -- overrides the clear() function in love.run
 
-#Example
+# Example
 ```Lua
 lick = require "lick"
 lick.reset = true -- reload the love.load everytime you save


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
